### PR TITLE
chore: move group message formatting logic from core to slack

### DIFF
--- a/.changeset/popular-rabbits-matter.md
+++ b/.changeset/popular-rabbits-matter.md
@@ -1,0 +1,11 @@
+---
+'@callstack/byorg-slack': patch
+'@callstack/byorg-core': patch
+'@callstack/byorg-discord': patch
+'@callstack/document-loaders': patch
+'@callstack/slack-rich-text': patch
+'@callstack/byorg-utils': patch
+---
+
+moved group message formatting from core to slack package
+improve logic for group message formatting and entity resolving

--- a/packages/core/src/ai/vercel.ts
+++ b/packages/core/src/ai/vercel.ts
@@ -216,7 +216,7 @@ function toUserContent(message: Message): UserContent {
   const files = message.attachments ?? [];
 
   return [
-    { type: 'text' as const, text: formatMessage(message) },
+    { type: 'text' as const, text: message.content },
     ...files.map((file) => ({
       type: 'image' as const,
       image: file.buffer,
@@ -225,22 +225,18 @@ function toUserContent(message: Message): UserContent {
   ];
 }
 
-function formatMessage(message: Message): string {
-  if (!message.senderId) {
-    return message.content;
-  }
-
-  return `[${message.senderId}] ${message.content}`;
-}
-
 function toNumberOrZero(n: number): number {
   return Number.isNaN(n) ? 0 : n;
 }
 
 function formatResolvedEntities(entities: Record<string, unknown>): string {
-  return `ENTITY DICTIONARY: \n
-      ${Object.entries(entities)
-        .map(([key, value]) => `'${key}' is '${JSON.stringify(value)}'`)
-        .join('\n')}
-    `;
+  if (Object.keys(entities).length) {
+    return `ENTITY DICTIONARY: \n
+    ${Object.entries(entities)
+      .map(([key, value]) => `'${key}' is '${JSON.stringify(value)}'`)
+      .join('\n')}
+      `;
+  } else {
+    return '';
+  }
 }

--- a/packages/core/src/ai/vercel.ts
+++ b/packages/core/src/ai/vercel.ts
@@ -230,13 +230,13 @@ function toNumberOrZero(n: number): number {
 }
 
 function formatResolvedEntities(entities: Record<string, unknown>): string {
-  if (Object.keys(entities).length) {
-    return `ENTITY DICTIONARY: \n
+  if (Object.keys(entities).length === 0) {
+    return '';
+  }
+
+  return `ENTITY DICTIONARY: \n
     ${Object.entries(entities)
       .map(([key, value]) => `'${key}' is '${JSON.stringify(value)}'`)
       .join('\n')}
       `;
-  } else {
-    return '';
-  }
 }

--- a/packages/slack/src/app.ts
+++ b/packages/slack/src/app.ts
@@ -10,7 +10,7 @@ import {
   ConversationMode,
 } from './types.js';
 import { fetchFileInfo, getThread } from './slack-api.js';
-import { toCoreMessage } from './messages.js';
+import { formatGroupMessage, toCoreMessage } from './messages.js';
 import { wait } from './utils.js';
 import { getBotId } from './bot-id.js';
 
@@ -62,6 +62,12 @@ function configureSlackApp(app: Application, slack: Slack.App): void {
     const messages = await Promise.all(
       thread.map((message) => toCoreMessage(message, botId, client)),
     );
+
+    if (conversationMode === 'public_channel') {
+      messages.forEach((message) => {
+        message.content = formatGroupMessage(message);
+      });
+    }
 
     logger.debug(`[SLACK] Fetched thread with ${messages.length} message(s).`);
 

--- a/packages/slack/src/messages.ts
+++ b/packages/slack/src/messages.ts
@@ -45,3 +45,11 @@ function fetchAttachments(
 
   return Promise.all(urls.map((file) => fetchFile(client, file)));
 }
+
+export function formatGroupMessage(message: Message): string {
+  if (!message.senderId) {
+    return message.content;
+  }
+
+  return `[${message.senderId}] ${message.content}`;
+}


### PR DESCRIPTION
### Summary
Move logic for group message formatting and fix for entity resolving.