### PR TITLE
fix: do not add sender id prefix for assistant group messages

### DIFF
--- a/.changeset/khaki-seas-refuse.md
+++ b/.changeset/khaki-seas-refuse.md
@@ -1,0 +1,6 @@
+---
+'@callstack/byorg-slack': minor
+'@callstack/byorg-core': minor
+---
+
+do not add sender id prefix for assistant group messages

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,6 @@
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:",
     "ai": "^4.0.3",
-    "vitest": "^2.1.5",
-    "zod": "^3.23.8"
+    "vitest": "catalog:"
   }
 }

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -24,7 +24,9 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@callstack/byorg-core": "0.3.1",
@@ -37,6 +39,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "catalog:",
-    "@rslib/core": "catalog:"
+    "@rslib/core": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/slack/src/__tests__/messagaes.test.ts
+++ b/packages/slack/src/__tests__/messagaes.test.ts
@@ -1,0 +1,34 @@
+import { expect, it, describe } from 'vitest';
+import { Message } from '@callstack/byorg-core';
+import { formatGroupMessage } from '../messages.js';
+
+describe('formatGroupMessage', () => {
+  it('should return content without sender id for assistant messages', () => {
+    const message: Message = {
+      role: 'assistant',
+      content: 'Hello world',
+      senderId: 'BOT123',
+    };
+
+    expect(formatGroupMessage(message)).toBe('Hello world');
+  });
+
+  it('should return content without sender id when senderId is missing', () => {
+    const message: Message = {
+      role: 'user',
+      content: 'Hello world',
+    };
+
+    expect(formatGroupMessage(message)).toBe('Hello world');
+  });
+
+  it('should prepend sender id for user messages', () => {
+    const message: Message = {
+      role: 'user',
+      content: 'Hello world',
+      senderId: 'USER123',
+    };
+
+    expect(formatGroupMessage(message)).toBe('[USER123] Hello world');
+  });
+});

--- a/packages/slack/src/messages.ts
+++ b/packages/slack/src/messages.ts
@@ -47,7 +47,8 @@ function fetchAttachments(
 }
 
 export function formatGroupMessage(message: Message): string {
-  if (!message.senderId) {
+  //  Do not add sender id for assistant messages, as LLMs tend repeat the format of their previous messages.
+  if (!message.senderId || message.role === 'assistant') {
     return message.content;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@rslib/core':
       specifier: ^0.1.0
       version: 0.1.0
+    vitest:
+      specifier: ^2.1.5
+      version: 2.1.5
 
 importers:
 
@@ -97,7 +100,7 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3(react@18.3.1)(zod@3.23.8)
       vitest:
-        specifier: ^2.1.5
+        specifier: 'catalog:'
         version: 2.1.5(@types/node@22.9.1)(sass-embedded@1.80.6)(terser@5.36.0)
 
   packages/discord:
@@ -198,6 +201,9 @@ importers:
       '@rslib/core':
         specifier: 'catalog:'
         version: 0.1.0(@microsoft/api-extractor@7.47.12(@types/node@22.9.1))(typescript@5.7.2)
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.5(@types/node@22.9.1)(sass-embedded@1.80.6)(terser@5.36.0)
 
   packages/slack-rich-text:
     dependencies:
@@ -4005,9 +4011,6 @@ packages:
   magic-bytes.js@1.10.0:
     resolution: {integrity: sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==}
 
-  magic-string@0.30.12:
-    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
-
   magic-string@0.30.13:
     resolution: {integrity: sha512-8rYBO+MsWkgjDSOvLomYnzhdwEG51olQ4zL5KXnNJWV5MNmrb4rTZdrtkhxjnD/QyZUqR/Z/XDsUs/4ej2nx0g==}
 
@@ -7785,7 +7788,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 2.1.5
       estree-walker: 3.0.3
-      magic-string: 0.30.12
+      magic-string: 0.30.13
     optionalDependencies:
       vite: 5.4.10(@types/node@22.9.1)(sass-embedded@1.80.6)(terser@5.36.0)
 
@@ -7801,7 +7804,7 @@ snapshots:
   '@vitest/snapshot@2.1.5':
     dependencies:
       '@vitest/pretty-format': 2.1.5
-      magic-string: 0.30.12
+      magic-string: 0.30.13
       pathe: 1.1.2
 
   '@vitest/spy@2.1.5':
@@ -10634,10 +10637,6 @@ snapshots:
 
   magic-bytes.js@1.10.0: {}
 
-  magic-string@0.30.12:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
-
   magic-string@0.30.13:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -12620,7 +12619,7 @@ snapshots:
   vite@5.4.10(@types/node@22.9.1)(sass-embedded@1.80.6)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.4.49
       rollup: 4.24.4
     optionalDependencies:
       '@types/node': 22.9.1
@@ -12640,7 +12639,7 @@ snapshots:
       chai: 5.1.2
       debug: 4.3.7
       expect-type: 1.1.0
-      magic-string: 0.30.12
+      magic-string: 0.30.13
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
 catalog:
   '@microsoft/api-extractor': '^7.47.12'
   '@rslib/core': '^0.1.0'
+  'vitest': '^2.1.5'


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Do not add sender id for assistant messages, as LLMs tend repeat the format of their previous messages.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
