### PR TITLE
chore: add cname to docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -27,3 +27,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docs/doc_build
+          # Use custom domain
+          cname: byorg.ai


### PR DESCRIPTION
### Summary
Adds a cname to deployed docs.

### Test plan
merge and see